### PR TITLE
refactor: replace useQueryState with useState for isGenerating

### DIFF
--- a/website/components/home/home-content.tsx
+++ b/website/components/home/home-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import {
 	callPythonFunction,
 	usePyodideStatus,
@@ -93,10 +93,7 @@ export default function HomeContent() {
 	const router = useRouter();
 	const { schedule, setSchedule, setEditedSchedule } = useContext(UserContext);
 	const [numExecutions, setNumExecutions] = React.useState(0);
-	const [isGenerating, setIsGenerating] = useQueryState(
-		"isGenerating",
-		parseAsBoolean.withDefault(false)
-	);
+	const [isGenerating, setIsGenerating] = useState(false);
 	// saved configs state
 	const [savedConfigs, setSavedConfigs] = React.useState<{
 		[key: string]: any;


### PR DESCRIPTION
This pull request makes a small update to the state management in the `HomeContent` component. The main change is replacing the use of `useQueryState` for the `isGenerating` state with the standard React `useState` hook. This simplifies the state handling for this variable.

Resolving issue 
- #28 