### PR TITLE
Impoved UI for academic calendar page 

### DIFF
--- a/website/components/academic-calendar/calendar-content.tsx
+++ b/website/components/academic-calendar/calendar-content.tsx
@@ -227,22 +227,32 @@ export default function CalendarContent() {
 					</div>
 
 					{/* Action Buttons - Compact row on mobile, Fixed column on desktop */}
-					<div className="flex flex-row flex-wrap justify-center gap-2 mt-4 mb-4 md:fixed md:bottom-8 md:left-8 md:flex-col md:items-start md:m-0 md:z-50 md:gap-3">
+
+					{/* <div className="flex flex-row flex-wrap justify-center gap-2 mt-4 mb-4 md:fixed md:bottom-8 md:left-8 md:flex-col md:items-start md:m-0 md:z-50 md:gap-3"> */}  
+
+					<div className="flex flex-row flex-wrap justify-center gap-2 mt-4 mb-4
+				     md:fixed md:bottom-8 md:left-6 md:flex-col md:items-stretch md:w-[calc(16rem-3rem)] md:z-50 md:gap-3 "> 
 					<motion.button
 						onClick={() => {
 							haptic("selection");
 							setShowHolidaysOnly(!showHolidaysOnly);
 							setVisibleEventsCount(0);
 						}}
-							className={`px-3 py-1.5 sm:px-6 sm:py-2 rounded-lg backdrop-blur-lg border transition-all duration-300 shadow-lg flex items-center gap-1.5 sm:gap-2 text-xs sm:text-base ${
-								showHolidaysOnly
-									? "bg-red-500/20 border-red-500/50 text-red-300 hover:bg-red-500/30"
-									: "bg-white/10 border-white/20 text-[#F0BB78] hover:bg-white/20"
-							}`}
+							// className={`px-3 py-1.5 sm:px-6 sm:py-2 rounded-lg backdrop-blur-lg border transition-all duration-300 shadow-lg flex items-center gap-1.5 sm:gap-2 text-xs sm:text-base ${
+						
+							className={`px-3 py-1.5 sm:px-6 sm:py-2 rounded-lg backdrop-blur-lg border
+							transition-all duration-300 shadow-lg
+							flex items-center justify-start gap-2 text-left
+							text-xs sm:text-base ${
+  								showHolidaysOnly
+   									 ? "bg-red-500/20 border-red-500/50 text-red-300 hover:bg-red-500/30"
+    								 : "bg-white/10 border-white/20 text-[#F0BB78] hover:bg-white/20"
+							   }`}
+
 							whileHover={{ scale: 1.05 }}
 							whileTap={{ scale: 0.95 }}
 						>
-							<Filter className="w-3.5 h-3.5 sm:w-5 sm:h-5" />
+							<Filter className="w-3.5 h-3.5 sm:w-6 sm:h-5" />
 							<span className="hidden sm:inline">
 								{showHolidaysOnly ? "All Events" : "Holidays Only"}
 							</span>
@@ -257,11 +267,17 @@ export default function CalendarContent() {
 						handleAddToCalendar();
 					}}
 						disabled={isLoading}
-							className="px-3 py-1.5 sm:px-6 sm:py-2 rounded-lg backdrop-blur-lg bg-white/10 border border-white/20 text-[#F0BB78] hover:bg-white/20 transition-all duration-300 shadow-lg flex items-center gap-1.5 sm:gap-2 text-xs sm:text-base"
+							// className="px-3 py-1.5 sm:px-6 sm:py-2 rounded-lg backdrop-blur-lg bg-white/10 border border-white/20 text-[#F0BB78] hover:bg-white/20 transition-all duration-300 shadow-lg flex items-center gap-1.5 sm:gap-2 text-xs sm:text-base"
+
+							className="px-3 py-1.5 sm:px-6 sm:py-2 rounded-lg backdrop-blur-lg
+							bg-white/10 border border-white/20 text-[#F0BB78]
+							hover:bg-white/20 transition-all duration-300 shadow-lg
+							flex items-center justify-start gap-2 text-left
+							text-xs sm:text-base" 
 							whileHover={{ scale: 1.05 }}
 							whileTap={{ scale: 0.95 }}
 						>
-							<Calendar className="w-3.5 h-3.5 sm:w-5 sm:h-5" />
+							<Calendar className="w-3.5 h-3.5 sm:w-8 sm:h-5" />
 							<span className="hidden sm:inline">
 								{isLoading ? "Adding..." : "Add to Google Calendar"}
 							</span>
@@ -279,7 +295,13 @@ export default function CalendarContent() {
 							);
 						}}
 						disabled={calendarData.length === 0}
-							className="px-3 py-1.5 sm:px-6 sm:py-2 rounded-lg backdrop-blur-lg bg-white/10 border border-white/20 text-[#F0BB78] hover:bg-white/20 transition-all duration-300 shadow-lg flex items-center gap-1.5 sm:gap-2 text-xs sm:text-base disabled:opacity-50 disabled:cursor-not-allowed"
+							// className="px-3 py-1.5 sm:px-6 sm:py-2 rounded-lg backdrop-blur-lg bg-white/10 border border-white/20 text-[#F0BB78] hover:bg-white/20 transition-all duration-300 shadow-lg flex items-center gap-1.5 sm:gap-2 text-xs sm:text-base disabled:opacity-50 disabled:cursor-not-allowed"
+							className="px-3 py-1.5 sm:px-6 sm:py-2 rounded-lg backdrop-blur-lg
+							bg-white/10 border border-white/20 text-[#F0BB78]
+							hover:bg-white/20 transition-all duration-300 shadow-lg
+							flex items-center justify-start gap-2 text-left
+							text-xs sm:text-base disabled:opacity-50 disabled:cursor-not-allowed"
+
 							whileHover={{ scale: 1.05 }}
 							whileTap={{ scale: 0.95 }}
 						>

--- a/website/components/layout/navbar.tsx
+++ b/website/components/layout/navbar.tsx
@@ -100,6 +100,10 @@ export default function Navbar() {
 		preventScrollOnSwipe: false, // Allow normal scrolling
 		delta: 50, // Minimum distance for swipe
 	});
+
+	// to diable "star on github" button on academic calendar page
+	const isAcademicCalendarPage = pathname.startsWith("/academic-calendar");
+
 	return (
 		<>
 			{/* Desktop Sidebar */}
@@ -171,8 +175,7 @@ export default function Navbar() {
 							);
 						})}
 					</div>
-
-					<div className="mt-auto pt-4 border-t border-white/5">
+					{!isAcademicCalendarPage && (<div className="mt-auto pt-4 border-t border-white/5">
 						<Link
 							href="https://github.com/tashifkhan/JIIT-time-table-website"
 							target="_blank"
@@ -182,7 +185,7 @@ export default function Navbar() {
 							<Github className="w-5 h-5 transition-all duration-200 text-slate-400 group-hover:text-slate-200 group-hover:scale-110" />
 							<span className="font-medium">Star on GitHub</span>
 						</Link>
-					</div>
+					</div>)}				
 				</div>
 			</motion.nav>
 


### PR DESCRIPTION
<img width="246" height="486" alt="image" src="https://github.com/user-attachments/assets/178d6a2b-7be7-4431-ab59-1eab23ee58b3" />
<img width="246" height="486" alt="image" src="https://github.com/user-attachments/assets/0863b509-a80c-4b97-a778-5920016b2f17" />

- Improved alignment and layout of action buttons on the Academic Calendar page.
- Adjusted button styling for better consistency with the sidebar layout.
- Hid the "Star on GitHub" button when the Academic Calendar page is active to prevent UI overlap.
